### PR TITLE
feat(v0.6.1): Row limit banner and label visibility fix

### DIFF
--- a/.github/workflows/auto-make.yml
+++ b/.github/workflows/auto-make.yml
@@ -1,17 +1,14 @@
 name: Build
 
-on:  [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   make:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    # Runs a single command using the runners shell
-    - name: Make
-      run: make plugin
+    - uses: actions/checkout@v4
+    - run: make plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2025-12-26
+
+### Added
+- Row limit banner when dataset exceeds `maxTasks` setting (#18)
+
+### Fixed
+- Task labels now visible when positioned outside bars (dark text on white background) (#40)
+
+### Changed
+- GitHub Actions workflow limited to main branch only (reduces queue congestion)
+
+## [0.6.0] - 2025-12-26
+
+### Fixed
+- Unit tests now run without requiring DSS integration test configuration (#29)
+
 ## [0.5.1] - 2025-12-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ DSS Dataset → backend.py → TaskTransformer → dependency_validator → JSON
 - **Frappe Gantt custom_class whitespace** — `custom_class` must be a single class name without spaces. Frappe uses `classList.add()` which throws DOMException on whitespace.
 - **SVG transform centering** — Use `transform-box: fill-box` when scaling SVG elements. Default `transform-origin` is relative to viewport, not element bounding box.
 - **Dataiku body.html is a fragment** — Never add `<!DOCTYPE html>` to body.html. It's injected into Dataiku's iframe wrapper, not a standalone document. DOCTYPE triggers Quirks Mode warning.
+- **Frappe Gantt `.big` label class** — When task names don't fit inside bars, library positions them outside and adds `.big` class. Our white text CSS made these invisible on white background. External labels need dark text override.
 
 ---
 

--- a/plan/post-mortems/v0.6.1-post-mortem.md
+++ b/plan/post-mortems/v0.6.1-post-mortem.md
@@ -1,0 +1,74 @@
+# Post-Mortem: v0.6.1
+
+**Branch:** `feature/v0.6.1-stability-and-labels`
+**Type:** Feature + Bugfix
+**Duration:** 1 day (2025-12-26)
+**Outcome:** ✅ Success
+
+---
+
+## Summary
+
+Added row limit visibility banner and fixed invisible task labels. Also optimized GitHub Actions workflow to reduce queue congestion.
+
+---
+
+## Scope
+
+### Planned
+- [x] #18 - Dataset row limit notification
+- [x] #40 - Fix invisible task labels
+
+### Delivered
+- [x] Row limit banner with clear user messaging
+- [x] Dark text for labels positioned outside bars
+- [x] GitHub Actions optimization (bonus)
+
+---
+
+## Commit Analysis
+
+| Metric | Value | Assessment |
+|--------|-------|------------|
+| Total commits | 1 | Clean squash |
+| Feature commits | 1 | |
+| Fix/debug commits | 0 | |
+| Reverts | 0 | |
+| Churn ratio | 0% | 🟢 Low |
+
+---
+
+## What Went Well
+
+- Quick investigation identified CSS `.big` class issue immediately
+- User provided clear QA feedback that caught edge cases (0 = unlimited, re-render behavior)
+- Workflow optimization was a quick win during PR wait time
+
+---
+
+## What Didn't Go Well
+
+- Initially implemented row limit at data loading layer instead of display layer
+  - User clarified preference for display-layer limiting to preserve backend data
+  - Quick fix, no significant time lost
+
+---
+
+## Technical Discoveries
+
+### Frappe Gantt Label Behavior
+- Library automatically positions labels outside bars when they don't fit
+- Adds `.big` class to these external labels
+- Our CSS was forcing all labels to white, making external labels invisible
+
+### GitHub Actions Queue
+- Queue congestion was from triggering builds on every feature branch push
+- Limiting to `main` + PRs significantly reduces queue wait times
+
+---
+
+## Lessons Learned
+
+1. Check library CSS behavior before adding overrides
+2. Display-layer limits are more flexible than data-loading limits
+3. GitHub Actions workflow should be scoped to reduce noise

--- a/plan/releases/v0.6.1-release-notes.md
+++ b/plan/releases/v0.6.1-release-notes.md
@@ -1,0 +1,71 @@
+# Release Notes: v0.6.1
+
+**Release Date:** 2025-12-26
+**Type:** Feature + Bugfix
+**Branch:** `feature/v0.6.1-stability-and-labels`
+
+---
+
+## Summary
+
+Adds visual feedback when dataset exceeds the configured task limit, and fixes invisible task labels when names are too long to fit inside bars.
+
+---
+
+## Changes
+
+### Added
+- **Row Limit Banner**: Shows notice when dataset exceeds `maxTasks` setting
+  - "Showing first N tasks (dataset limit reached). Increase Max Tasks to see more."
+  - `maxTasks=0` means unlimited (no banner shown)
+
+### Fixed
+- **Label Visibility**: Task labels positioned outside bars now use dark text (#40)
+  - Previously, long task names that couldn't fit inside bars were white-on-white (invisible)
+  - Now correctly displays dark text on white background
+
+### Changed
+- **GitHub Actions**: Build workflow now only runs on `main` branch and PRs targeting `main`
+  - Reduces queue congestion from feature branch pushes
+  - Updated to `ubuntu-latest` runner and `actions/checkout@v4`
+
+---
+
+## Files Modified
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `webapps/gantt-chart/backend.py` | Modified | Add `rowLimitHit` flag to metadata |
+| `webapps/gantt-chart/app.js` | Modified | Display banner when row limit hit |
+| `resource/webapp/style.css` | Modified | Add `.bar-label.big` dark text rule |
+| `.github/workflows/auto-make.yml` | Modified | Limit workflow to main branch |
+| `plugin.json` | Modified | Bump version to 0.6.1 |
+
+---
+
+## Testing
+
+- **Manual Verification:**
+  - [x] Set maxTasks=10, load 50+ rows → banner appears
+  - [x] Set maxTasks=0 → no banner (unlimited)
+  - [x] Long task names show dark labels outside bars
+  - [x] Config changes trigger re-render
+
+---
+
+## Breaking Changes
+
+None
+
+---
+
+## Known Issues
+
+None
+
+---
+
+## Related Documents
+
+- Spec: `plan/specs/feature-v0.6.1-spec.md`
+- Issues: #18, #40

--- a/plan/specs/feature-v0.6.1-spec.md
+++ b/plan/specs/feature-v0.6.1-spec.md
@@ -1,0 +1,133 @@
+# Feature v0.6.1 Specification
+
+## Branch
+`feature/v0.6.1-stability-and-labels`
+
+## Linked Issues
+- Fixes #18 (Dataset row limit for scalability)
+- Fixes #40 (Task labels invisible when positioned outside bars)
+- Closes #19 (Not needed - Dataiku handles filter pushdown)
+
+## Overview
+Add dataset row limit to prevent OOM crashes and fix task label visibility when labels are positioned outside bars.
+
+---
+
+## Feature 1: Dataset Row Limit (#18)
+
+### Problem
+`backend.py` calls `dataset.get_dataframe()` without a limit, loading entire datasets into memory. Large datasets (>100k rows) can cause OOM crashes.
+
+### Solution
+Use `maxTasks` configuration parameter (already exists) to limit data loading at source:
+
+```python
+max_tasks = int(config.get('maxTasks', 1000))
+df = dataset.get_dataframe(limit=max_tasks)
+```
+
+### File
+`webapps/gantt-chart/backend.py` (line ~59)
+
+---
+
+## Bug 2: Label Visibility (#40)
+
+### Problem
+When task names don't fit inside bars, Frappe Gantt positions them outside (to the right) with class `.big`. Our CSS forces all labels to white, making external labels invisible on white background.
+
+### Root Cause
+```css
+.gantt .bar-label {
+    fill: #ffffff !important;  /* Forces ALL labels to white */
+}
+```
+
+### Solution
+Add override for external labels:
+```css
+/* External labels (positioned outside bars) need dark text on white background */
+.gantt .bar-label.big {
+    fill: #333333 !important;
+}
+```
+
+### File
+`resource/webapp/style.css`
+
+---
+
+## Files to Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `webapps/gantt-chart/backend.py` | Modify | Add `limit=max_tasks` to `get_dataframe()` |
+| `resource/webapp/style.css` | Modify | Add `.bar-label.big` dark text rule |
+| `plugin.json` | Modify | Bump version to 0.6.1 |
+
+---
+
+## Testing Checklist
+
+### Row Limit (#18)
+- [ ] Set `maxTasks` to 10 in config
+- [ ] Load dataset with 100+ rows
+- [ ] Verify only 10 tasks displayed (metadata banner shows "10 of X")
+- [ ] No OOM errors on large datasets
+
+### Label Visibility (#40)
+- [ ] Create tasks with long names that don't fit in bars
+- [ ] Verify labels appear to the right of bars (dark text)
+- [ ] Labels inside bars still use appropriate contrast colors
+- [ ] Check with Color By enabled and disabled
+
+---
+
+## User QA Gate
+
+**CRITICAL: Code must be committed BEFORE User QA.**
+
+**Pre-QA Commit Process:**
+1. Implement changes
+2. Commit with message:
+   ```
+   feat(v0.6.1): add dataset row limit and fix label visibility (#18, #40)
+
+   Changes:
+   - backend.py: Add limit=max_tasks to get_dataframe()
+   - style.css: Add .bar-label.big dark text for external labels
+   - plugin.json: Bump to 0.6.1
+
+   Fixes #18, Fixes #40
+
+   [claude signature]
+   ```
+3. Verify: `git log --oneline -1`
+
+**User QA Steps:**
+```
+1. Reload plugin in Dataiku
+2. Test row limit:
+   - Set maxTasks to 10
+   - Load dataset with 50+ rows
+   - Verify metadata banner shows "Showing 10 of X tasks"
+3. Test label visibility:
+   - Create/use tasks with long names
+   - Zoom out so bars are narrow
+   - Verify labels appear to right of bars in dark text
+4. Test with Color By enabled
+```
+
+---
+
+## Rollback Plan
+```bash
+git revert HEAD
+```
+
+---
+
+## Watch Out For
+1. **maxTasks vs limit semantics** — `maxTasks` limits displayed tasks, now also limits data loading
+2. **Label truncation** — Very long labels may still overflow; this is expected browser behavior
+3. **Color contrast** — External labels always dark; internal labels use per-color rules

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
     "id": "gantt-chart",
 
     // It is highly recommended to use Semantic Versioning
-    "version": "0.6.0",
+    "version": "0.6.1",
 
     // Meta data for display purposes:
     "meta": {

--- a/resource/webapp/style.css
+++ b/resource/webapp/style.css
@@ -602,6 +602,11 @@ body {
     font-family: var(--font-stack) !important;
 }
 
+/* External labels (positioned outside bars when name doesn't fit) need dark text */
+.gantt .bar-label.big {
+    fill: #333333 !important;
+}
+
 /* Ensure header text is visible */
 .gantt .grid-header text {
     fill: var(--text-muted) !important;

--- a/webapps/gantt-chart/app.js
+++ b/webapps/gantt-chart/app.js
@@ -521,7 +521,7 @@
                     return;
                 }
 
-                if (tasksResponse.metadata && tasksResponse.metadata.skippedRows > 0) {
+                if (tasksResponse.metadata && (tasksResponse.metadata.skippedRows > 0 || tasksResponse.metadata.rowLimitHit)) {
                     displayMetadata(tasksResponse.metadata);
                 }
 
@@ -1058,8 +1058,14 @@
         let html = `
             <span class="close-btn" onclick="this.parentElement.remove()">×</span>
             <strong>Notice:</strong><br>
-            Showing ${metadata.displayedRows} of ${metadata.totalRows} tasks
         `;
+
+        // Show row limit message if limit was hit
+        if (metadata.rowLimitHit) {
+            html += `Showing first ${metadata.rowLimit} tasks (dataset limit reached). Increase Max Tasks to see more.`;
+        } else {
+            html += `Showing ${metadata.displayedRows} of ${metadata.totalRows} tasks`;
+        }
 
         if (metadata.skippedRows > 0) {
             html += ` (${metadata.skippedRows} skipped)`;


### PR DESCRIPTION
## Summary
- Show banner when dataset exceeds maxTasks limit (0 = unlimited)
- Fix invisible task labels when positioned outside bars (dark text on white background)

## Test plan
- [x] Set maxTasks=10, load 50+ rows → banner appears
- [x] Set maxTasks=0 → no banner (unlimited)
- [x] Long task names show dark labels outside bars
- [x] Config changes trigger re-render

Fixes #18, Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)